### PR TITLE
POST /repos/:owner/:repo/git/blobs

### DIFF
--- a/GET/repos/owner/repo/git/blobs/:sha
+++ b/GET/repos/owner/repo/git/blobs/:sha
@@ -1,0 +1,7 @@
+{
+  "content": "Q29udGVudCBvZiB0aGUgYmxvYg==\n",
+  "encoding": "base64",
+  "url": "https://api.github.com/repos/octocat/example/git/blobs/3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15",
+  "sha": "3a0f86fb8db8eea7ccbb9a95f325ddbedfb25e15",
+  "size": 19
+}


### PR DESCRIPTION
{
  "content": "Content of the blob",
  "encoding": "utf-8"
}